### PR TITLE
test removing the unlock button from the bot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -419,16 +419,16 @@ fastify.addHook("onReady", async () => {
         return;
       }
 
-      const row = new MessageActionRow().addComponents(
+      /* const row = new MessageActionRow().addComponents(
         new MessageButton()
           .setCustomId("unlock")
           .setLabel("Unlock Discord")
           .setStyle("PRIMARY")
           .setEmoji("🔐")
-      );
+      ); */
       await channel.send({
         content: `Hello ${member.user}! Are you ready to be a part of the Unlock Community? Type /unlock to start.`,
-        components: [row],
+        // components: [row],
       });
     });
 


### PR DESCRIPTION
commenting out button creation and button display to see if it has any effect

folks will need to type in /unlock to unlock

we've seen this work successfully on 1Oct, so we know that works

left in the handling of the button interaction for now, in case someone clicks one of the old buttons that have been previously published in the channel

will check back in in a week or so and if things seem the same, may actually remove those lines (instead of just commenting them out)